### PR TITLE
sapphire: Patched thermal to Fix fast charging on AOSP roms

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -919,7 +919,7 @@ vendor/etc/thermal-map.conf
 vendor/etc/thermal-mgame.conf
 vendor/etc/thermal-navigation.conf
 vendor/etc/thermal-nolimits.conf
-vendor/etc/thermal-normal.conf
+vendor/etc/thermal-normal.conf|d44ba836677e9e04d67040ced60ef7abe56f7aae
 vendor/etc/thermal-phone.conf
 vendor/etc/thermal-tgame.conf
 vendor/etc/thermal-video.conf


### PR DESCRIPTION
[1] - Correct the nonsense that Xiaomi does in thermal
[2] - Until fixed in OSS kernel

Changes:

* Stock: [Normal-MONITOR-BAT]
algo_type monitor
sensor  VIRTUAL-SENSOR
device  battery
polling  1000
trig  35000 36000 37000 38000 39000 40000 41000 42000 43000 44000 46000 47000
clr   34000 35000 36000 37000 38000 39000 40000 41000 42000 43000 45000 46000
target  500  700  801  902  1103 1205 1207 1309 1311 1313 1414 1515

* Current change: [Normal-MONITOR-BAT]
algo_type monitor
sensor  battery
device  battery
polling  1000
trig  38000 38500 39000 39500 40000 40500 41000 41500 42000 42500 43000 43500
clr   37000 37500 38000 38500 39000 39500 40000 40500 41000 41500 42000 42500
target  801  802  803  904  1105 1206 1207 1309 1311 1313 1414 1515

[3] - Remove sensor  VIRTUAL-SENSOR
[4] - Thanks: @offpcx9